### PR TITLE
Removing loop over entity translations after saving in upsertEntities()

### DIFF
--- a/src/Service/Importer.php
+++ b/src/Service/Importer.php
@@ -270,9 +270,6 @@ class Importer implements ImporterInterface {
       }
       */
       $entity->save();
-      foreach ($entity->getTranslationLanguages(FALSE) as $language) {
-        $entity->getTranslation($language->getId())->save();
-      }
     }
   }
 


### PR DESCRIPTION
After a Lark Import, saving nested paragraphs on translated nodes gives a fatal error:

> Drupal\Core\Entity\EntityStorageException: An existing default revision of the 'paragraph' entity type can not be changed to a non-default revision. in Drupal\Core\Entity\Sql\SqlContentEntityStorage->save() (line 815 of core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php). 

Since all translations are already attached to the entity object, a single `$entity->save()` will save them all. Drupal's storage layer iterates all attached translations in one operation.

That means the translation loop in `Importer.php` is redundant and harmful.